### PR TITLE
Handles get_ip_address() output in case of dns failure

### DIFF
--- a/onionperf/util.py
+++ b/onionperf/util.py
@@ -136,7 +136,7 @@ def get_ip_address():
     except IOError:
         logging.warning("DNS failed to resolve, could not retrieve your public IP address. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally...")
     except Exception as e:
-        logging.warning("There was a problem retrieving your public IP address, the error was {0}. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally. Falling back to finding your IP locally...".format(e))
+        logging.warning("There was a problem retrieving your public IP address, the error was {0}. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally...".format(e))
     if ip_address is None:
         ip_address = find_ip_address_local()
     return ip_address

--- a/onionperf/util.py
+++ b/onionperf/util.py
@@ -135,8 +135,6 @@ def get_ip_address():
         ip_address = find_ip_address_url(data)
     except IOError:
         logging.warning("DNS failed to resolve, could not retrieve your public IP address. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally...")
-    except Exception as e:
-        logging.warning("There was a problem retrieving your public IP address, the error was {0}. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally...".format(e))
     if ip_address is None:
         ip_address = find_ip_address_local()
     return ip_address

--- a/onionperf/util.py
+++ b/onionperf/util.py
@@ -133,8 +133,10 @@ def get_ip_address():
     try:
         data = urllib.urlopen('https://check.torproject.org/').read()
         ip_address = find_ip_address_url(data)
-    except:
-        pass
+    except IOError:
+        logging.warning("DNS failed to resolve, could not retrieve your public IP address. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally...")
+    except Exception as e:
+        logging.warning("There was a problem retrieving your public IP address, the error was {0}. This will affect measurements unless your machine has a public IP address. Falling back to finding your IP locally. Falling back to finding your IP locally...".format(e))
     if ip_address is None:
         ip_address = find_ip_address_local()
     return ip_address

--- a/onionperf/util.py
+++ b/onionperf/util.py
@@ -129,10 +129,14 @@ def find_ip_address_local():
     return ip_address
  
 def get_ip_address():
-    data = urllib.urlopen('https://check.torproject.org/').read()
-    ip_address = find_ip_address_url(data) 
+    ip_address = None
+    try:
+        data = urllib.urlopen('https://check.torproject.org/').read()
+        ip_address = find_ip_address_url(data)
+    except:
+        pass
     if ip_address is None:
-        ip_address = find_ip_address_local() 
+        ip_address = find_ip_address_local()
     return ip_address
 
 def get_random_free_port():


### PR DESCRIPTION
Onionperf normally needs a public IP address for the tgen server. It checks https://check.torproject.org to find it, but in cases where DNS fails a local IP address may still be useful. If using onion services, a public IP address is not needed. If using a testing Tor network with private addressing (chutney) a public IP address is also not needed, even when not using onion services.