### PR TITLE
Adds support for getting extra configuration from an env variable.

### DIFF
--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -171,6 +171,9 @@ class Measurement(object):
         self.hs_service_id = None
         self.hs_v3_service_id = None
         self.www_docroot = "{0}/htdocs".format(self.datadir_path)
+        self.base_config = ""
+        if "BASETORRC" in os.environ:
+            self.base_config = os.environ['BASETORRC']
 
     def run(self, do_onion=True, do_inet=True, client_tgen_listen_port=58888, client_tgen_connect_ip='0.0.0.0', client_tgen_connect_port=8080, client_tor_ctl_port=59050, client_tor_socks_port=59000,
              server_tgen_listen_port=8080, server_tor_ctl_port=59051, server_tor_socks_port=59001):
@@ -358,7 +361,7 @@ class Measurement(object):
         tor_datadir = "{0}/tor-{1}".format(self.datadir_path, name)
         if not os.path.exists(tor_datadir): os.makedirs(tor_datadir)
 
-        tor_config_template = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+        tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
 WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards 0\nDataDirectory {2}\nLog INFO stdout\n"
         tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)
 

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -171,9 +171,7 @@ class Measurement(object):
         self.hs_service_id = None
         self.hs_v3_service_id = None
         self.www_docroot = "{0}/htdocs".format(self.datadir_path)
-        self.base_config = ""
-        if "BASETORRC" in os.environ:
-            self.base_config = os.environ['BASETORRC']
+        self.base_config = os.environ['BASETORRC'] if "BASETORRC" in os.environ else ""
 
     def run(self, do_onion=True, do_inet=True, client_tgen_listen_port=58888, client_tgen_connect_ip='0.0.0.0', client_tgen_connect_port=8080, client_tor_ctl_port=59050, client_tor_socks_port=59000,
              server_tgen_listen_port=8080, server_tor_ctl_port=59051, server_tor_socks_port=59001):


### PR DESCRIPTION
This is a useful feature where tor configuration is generated on the fly and needs to be passed to OnionPerf - such as chutney Tor testing network configuration which is generated at runtime.