### PR TITLE
Tor configuration in OnionPerf

### DIFF
--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -347,6 +347,12 @@ class Measurement(object):
 
         return tgen_writable
 
+    def __create_tor_config(self, control_port, socks_port, tor_datadir):
+        tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards 0\nDataDirectory {2}\nLog INFO stdout\n"
+        tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)
+        return tor_config
+
     def __start_tor_client(self, control_port, socks_port):
         return self.__start_tor("client", control_port, socks_port)
 
@@ -355,14 +361,10 @@ class Measurement(object):
 
     def __start_tor(self, name, control_port, socks_port, hs_port_mapping=None):
         logging.info("Starting Tor {0} process with ControlPort={1}, SocksPort={2}...".format(name, control_port, socks_port))
-
         tor_datadir = "{0}/tor-{1}".format(self.datadir_path, name)
+
         if not os.path.exists(tor_datadir): os.makedirs(tor_datadir)
-
-        tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
-WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards 0\nDataDirectory {2}\nLog INFO stdout\n"
-        tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)
-
+        tor_config = self.__create_tor_config(control_port,socks_port,tor_datadir)
         tor_logpath = "{0}/onionperf.tor.log".format(tor_datadir)
         tor_writable = util.FileWritable(tor_logpath)
         logging.info("Logging Tor {0} process output to {1}".format(name, tor_logpath))

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -160,7 +160,7 @@ def logrotate_thread_task(writables, tgen_writable, torctl_writable, docroot, ni
 
 class Measurement(object):
 
-    def __init__(self, tor_bin_path, tgen_bin_path, datadir_path, nickname, oneshot,additional_client_conf=None):
+    def __init__(self, tor_bin_path, tgen_bin_path, datadir_path, nickname, oneshot, additional_client_conf=None, torclient_conf_file=None, torserver_conf_file=None):
         self.tor_bin_path = tor_bin_path
         self.tgen_bin_path = tgen_bin_path
         self.datadir_path = datadir_path
@@ -173,6 +173,8 @@ class Measurement(object):
         self.www_docroot = "{0}/htdocs".format(self.datadir_path)
         self.base_config = os.environ['BASETORRC'] if "BASETORRC" in os.environ else ""
         self.additional_client_conf = additional_client_conf
+        self.torclient_conf_file = torclient_conf_file
+        self.torserver_conf_file = torserver_conf_file
 
     def run(self, do_onion=True, do_inet=True, client_tgen_listen_port=58888, client_tgen_connect_ip='0.0.0.0', client_tgen_connect_port=8080, client_tor_ctl_port=59050, client_tor_socks_port=59000,
              server_tgen_listen_port=8080, server_tor_ctl_port=59051, server_tor_socks_port=59001):

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -349,6 +349,19 @@ class Measurement(object):
         return tgen_writable
 
     def __create_tor_config(self, control_port, socks_port, tor_datadir, name):
+        """This function generates a tor configuration based on a default template.
+        This template is appended to any tor configuration inherited via the
+	BASETORRC environment variable. Configuration in any additional tor
+        client/server config files are then appended depending on whether "name" points
+        to client or server.  Any additional client configuration specified as
+        a string is also added if the client is being configured.
+
+	Finally, if there is no specific mention of either using Entry Guards
+       (by default enabled) or bridges (by default disabled) the configurator appends
+       an option to override the use of Entry Guards, to avoid measuring the guard
+       node multiple times.
+        """
+
         tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
 WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards 0\nDataDirectory {2}\nLog INFO stdout\n"
         tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -367,6 +367,12 @@ class Measurement(object):
         tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
 WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory {2}\nLog INFO stdout\n"
         tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)
+        if name == "server" and self.torserver_conf_file:
+            with open(self.torserver_conf_file, 'r') as f:
+                tor_config += f.read()
+        if name == "client" and self.torclient_conf_file:
+            with open(self.torclient_conf_file, 'r') as f:
+                tor_config = tor_config + f.read()
         if name == "client" and self.additional_client_conf:
             tor_config += self.additional_client_conf
         if not 'UseEntryGuards' in tor_config and not 'UseBridges' in tor_config:

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -350,7 +350,7 @@ class Measurement(object):
 
         return tgen_writable
 
-    def __create_tor_config(self, control_port, socks_port, tor_datadir, name):
+    def create_tor_config(self, control_port, socks_port, tor_datadir, name):
         """This function generates a tor configuration based on a default template.
         This template is appended to any tor configuration inherited via the
 	BASETORRC environment variable. Configuration in any additional tor
@@ -382,7 +382,7 @@ WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards
         tor_datadir = "{0}/tor-{1}".format(self.datadir_path, name)
 
         if not os.path.exists(tor_datadir): os.makedirs(tor_datadir)
-        tor_config = self.__create_tor_config(control_port,socks_port,tor_datadir,name)
+        tor_config = self.create_tor_config(control_port,socks_port,tor_datadir,name)
 
         tor_logpath = "{0}/onionperf.tor.log".format(tor_datadir)
         tor_writable = util.FileWritable(tor_logpath)

--- a/onionperf/measurement.py
+++ b/onionperf/measurement.py
@@ -365,10 +365,12 @@ class Measurement(object):
         """
 
         tor_config_template = self.base_config + "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort {0}\nSocksPort {1}\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
-WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nUseEntryGuards 0\nDataDirectory {2}\nLog INFO stdout\n"
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory {2}\nLog INFO stdout\n"
         tor_config = tor_config_template.format(control_port, socks_port, tor_datadir)
         if name == "client" and self.additional_client_conf:
             tor_config += self.additional_client_conf
+        if not 'UseEntryGuards' in tor_config and not 'UseBridges' in tor_config:
+            tor_config += "UseEntryGuards 0"
         return tor_config
 
     def __start_tor_client(self, control_port, socks_port):

--- a/onionperf/onionperf
+++ b/onionperf/onionperf
@@ -150,6 +150,24 @@ def main():
         action="store_true", dest="oneshot",
         default=False)
 
+    measure_parser.add_argument('--additional-client-conf',
+        help="""Additional configuration lines for the Tor client, for example bridge lines""",
+        metavar="CONFIG", type=str,
+        action="store", dest="additional_client_conf",
+        default="")
+
+    measure_parser.add_argument('--torclient-conf-file',
+        help="""Configuration file for the Tor client""",
+        metavar="CONFIG", type=str,
+        action="store", dest="torclient_conf_file",
+        default="")
+
+    measure_parser.add_argument('--torserver-conf-file',
+        help="""Configuration file for the Tor server""",
+        metavar="CONFIG", type=str,
+        action="store", dest="torserver_conf_file",
+        default="")
+
     measure_parser.add_argument('--tgen-connect-ip',
         help="""the TGen client connect IP address ADDR, or 0.0.0.0 to do an external IP lookup; must be Internet-accessible for non-onion downloads to work""",
         metavar="ADDR", type=type_str_ip_in,
@@ -368,7 +386,7 @@ def measure(args):
         server_tor_ctl_port = util.get_random_free_port()
         server_tor_socks_port = util.get_random_free_port()
 
-        meas = Measurement(args.torpath, args.tgenpath, args.prefix, args.nickname, args.oneshot)
+        meas = Measurement(args.torpath, args.tgenpath, args.prefix, args.nickname, args.oneshot, args.additional_client_conf, args.torclient_conf_file, args.torserver_conf_file)
         meas.run(do_onion=args.do_onion, do_inet=args.do_inet,
              client_tgen_listen_port=client_tgen_port, client_tgen_connect_ip=client_connect_ip, client_tgen_connect_port=client_connect_port, client_tor_ctl_port=client_tor_ctl_port, client_tor_socks_port=client_tor_socks_port,
              server_tgen_listen_port=server_tgen_port, server_tor_ctl_port=server_tor_ctl_port, server_tor_socks_port=server_tor_socks_port)

--- a/onionperf/tests/data/config
+++ b/onionperf/tests/data/config
@@ -1,0 +1,1 @@
+UseBridges 1

--- a/onionperf/tests/test_measurement.py
+++ b/onionperf/tests/test_measurement.py
@@ -1,0 +1,111 @@
+import os
+import pkg_resources
+from nose.tools import assert_equals
+from onionperf import measurement
+
+
+def absolute_data_path(relative_path=""):
+    """
+    Returns an absolute path for test data given a relative path.
+    """
+    return pkg_resources.resource_filename("onionperf",
+                                           "tests/data/" + relative_path)
+
+
+DATA_DIR = absolute_data_path()
+
+
+def test_create_tor_config_env_var():
+    """
+    This test uses Measurement.create_tor_config to 
+    create a configuration string for tor when the BASETORRC env variable is set. 
+    It first sets the environment variable, then initializes an empty
+    measurement and then calls create_tor_config with a series of well known
+    variables. The resulting config is tested against the expected config for
+    both client and server. Also
+    this tests if the contents of the env variable are correctly recorded in
+    the class attribute base_config.
+    The environment variable is unset only if the test is successful.
+    """
+
+    os.environ["BASETORRC"] = "UseBridges 1\n"
+    meas = measurement.Measurement(None, None, None, None, None, None, None,
+                                   None)
+    known_config = "UseBridges 1\nRunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\n"
+
+    config_client = meas.create_tor_config(9001, 9050, "/tmp/", "client")
+    config_server = meas.create_tor_config(9001, 9050, "/tmp/", "server")
+    assert_equals(config_client, known_config)
+    assert_equals(config_server, known_config)
+    assert_equals(meas.base_config, "UseBridges 1\n")
+    del os.environ["BASETORRC"]
+
+
+def test_create_tor_config_client_lines():
+    """
+    This test uses Measurement.create_tor_config to create a configuration
+    string for tor when additional client config is specified.
+    It initializes an empty measurement, setting the additional_client_config
+    parameter. The resulting configuration is then tested against the expected
+    configuration for both client and server.
+    """
+
+    known_config = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseBridges 1\n"
+
+    known_config_server = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseEntryGuards 0"
+
+    meas = measurement.Measurement(None, None, None, None, None,
+                                   "UseBridges 1\n", None, None)
+    config_client = meas.create_tor_config(9001, 9050, "/tmp/", "client")
+    config_server = meas.create_tor_config(9001, 9050, "/tmp/", "server")
+    assert_equals(config_client, known_config)
+    assert_equals(config_server, known_config_server)
+
+
+def test_create_tor_config_client_file():
+    """
+    This test uses Measurement.create_tor_config to create a configuration
+    string for tor when additional client config is specified.
+    It initializes an empty measurement, setting the additional_client_config
+    parameter. The resulting configuration is then tested against the expected
+    configuration for both client and server.
+    """
+
+    known_config_server = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseEntryGuards 0"
+
+    known_config = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseBridges 1\n"
+
+    meas = measurement.Measurement(None, None, None, None, None, None,
+                                   absolute_data_path("config"), None)
+    config_client = meas.create_tor_config(9001, 9050, "/tmp/", "client")
+    config_server = meas.create_tor_config(9001, 9050, "/tmp/", "server")
+    assert_equals(config_client, known_config)
+    assert_equals(config_server, known_config_server)
+
+
+def test_create_tor_config_server_file():
+    """
+    This test uses Measurement.create_tor_config to create a configuration
+    string for tor when additional server config is specified in a file.
+    It initializes an empty measurement, setting the additional_client_config
+    parameter. The resulting configuration is then tested against the expected
+    configuration for both client and server.
+    """
+
+    known_config_server = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseBridges 1\n"
+
+    known_config = "RunAsDaemon 0\nORPort 0\nDirPort 0\nControlPort 9001\nSocksPort 9050\nSocksListenAddress 127.0.0.1\nClientOnly 1\n\
+WarnUnsafeSocks 0\nSafeLogging 0\nMaxCircuitDirtiness 60 seconds\nDataDirectory /tmp/\nLog INFO stdout\nUseEntryGuards 0"
+
+    meas = measurement.Measurement(None, None, None, None, None, None, None,
+                                   absolute_data_path("config"))
+    config_client = meas.create_tor_config(9001, 9050, "/tmp/", "client")
+    config_server = meas.create_tor_config(9001, 9050, "/tmp/", "server")
+    assert_equals(config_client, known_config)
+    assert_equals(config_server, known_config_server)


### PR DESCRIPTION
Onionperf uses a template configuration string that it passes to both server and client. Additional configuration lines can be added via in an environment variable. This pull requests splits the configuration into server and client and adds options for extending it either from a string 
or from a configuration file, per server or per client. 
The code for configuring tor has been split in its own function. Comments and initial tests for this function have also been added.