### PR TITLE
Removes DATAPERC fields in case of transfer errors

### DIFF
--- a/onionperf/analysis.py
+++ b/onionperf/analysis.py
@@ -236,6 +236,9 @@ class Analysis(object):
                                         if decile in xfer_db['elapsed_seconds']['payload_progress'] and xfer_db['elapsed_seconds']['payload_progress'][decile] is not None:
                                             decile_as_int = int(float(decile) * 100)
                                             d['DATAPERC{0}'.format(decile_as_int)] = ts_to_str(xfer_db['unix_ts_start'] + xfer_db['elapsed_seconds']['payload_progress'][decile])
+                                else:
+                                    for i in range(1, 10):
+                                        d.pop('DATAPERC{}0'.format(i))
 
                                 if 'last_byte' in xfer_db['elapsed_seconds']:
                                     d['DATACOMPLETE'] = ts_to_str(xfer_db['unix_ts_start'] + xfer_db['elapsed_seconds']['last_byte'])


### PR DESCRIPTION
As per further discussion of Tor Metrics bug #29374: DATAPERC fields in the torperf output are optional, and in case of transfer errors (where there is no payload_progress field in the json output of onionperf) these fields should also be excluded (rather than set to 0.0, which is the current behaviour). Nothing relies on these fields being present further down the data processing pipeline.
