### PR TITLE
Adds support for recording partial completion times

### DIFF
--- a/onionperf/analysis.py
+++ b/onionperf/analysis.py
@@ -414,9 +414,14 @@ class Transfer(object):
         self.id = tid
         self.last_event = None
         self.payload_progress = {decile:None for decile in [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]}
+        self.payload_bytes = {partial:None for partial in [10240, 20480, 51200, 102400, 1048576, 2097152, 5242880]}
 
     def add_event(self, status_event):
         progress_frac = float(status_event.payload_bytes_status) / float(status_event.filesize_bytes)
+        progress = float(status_event.payload_bytes_status)
+        for partial in sorted(self.payload_bytes.keys()):
+            if progress >= partial and self.payload_bytes[partial] is None:
+                self.payload_bytes[partial] = status_event.unix_ts_end
         for decile in sorted(self.payload_progress.keys()):
             if progress_frac >= decile and self.payload_progress[decile] is None:
                 self.payload_progress[decile] = status_event.unix_ts_end
@@ -429,6 +434,7 @@ class Transfer(object):
         d = e.__dict__
         if not e.is_error:
             d['elapsed_seconds']['payload_progress'] = {decile: self.payload_progress[decile] - e.unix_ts_start for decile in self.payload_progress if self.payload_progress[decile] is not None}
+            d['elapsed_seconds']['payload_bytes'] = {partial: self.payload_bytes[partial] - e.unix_ts_start for partial in self.payload_bytes if self.payload_bytes[partial] is not None}
         return d
 
 class Parser(object, metaclass=ABCMeta):

--- a/onionperf/analysis.py
+++ b/onionperf/analysis.py
@@ -433,8 +433,8 @@ class Transfer(object):
             return None
         d = e.__dict__
         if not e.is_error:
-            d['elapsed_seconds']['payload_progress'] = {decile: self.payload_progress[decile] - e.unix_ts_start for decile in self.payload_progress if self.payload_progress[decile] is not None}
-            d['elapsed_seconds']['payload_bytes'] = {partial: self.payload_bytes[partial] - e.unix_ts_start for partial in self.payload_bytes if self.payload_bytes[partial] is not None}
+            d['elapsed_seconds']['payload_progress'] = {decile: round(self.payload_progress[decile] - e.unix_ts_start, 6) for decile in self.payload_progress if self.payload_progress[decile] is not None}
+            d['elapsed_seconds']['bytes_progress'] = {partial: round(self.payload_bytes[partial] - e.unix_ts_start, 6) for partial in self.payload_bytes if self.payload_bytes[partial] is not None}
         return d
 
 class Parser(object, metaclass=ABCMeta):


### PR DESCRIPTION
This pull request adds support for recording partial completion timestamps, both in json and torperf produced analysis files. The data is recorded the same way as the percentile data, and only in case where there are no errors. An example of the resulting fields in the torperf file (in the case of a 5m download) are: PARTIAL1048576=1555678482.70 PARTIAL51200=1555678479.75 PARTIAL5242880=1555678495.97 

For a 1m download, only values PARTIAL1048576 and PARTIAL51200 are recorded, and similarly, for a 50k download, only PARTIAL51200 will be recorded. 
We could only record PARTIAL values smaller than the total size of the download (we already record DATAPERC100, which is the same timestamp/value, equivalent to 100% download), however having the field might help process things in an automated fashion further down the pipeline - happy to make changes if this is not the case.

Finally - the names of the fields may be changed to PARTIAL{50k,1m,5m} although I've noticed all the other fields in the tpf file use the value in bytes and not the human readable version. Suggestions welcome.